### PR TITLE
Added methods to allow editing of Cards array

### DIFF
--- a/src/payment.coffee
+++ b/src/payment.coffee
@@ -416,6 +416,18 @@ class Payment
     QJ.on el, 'keyup', setCardType
     QJ.on el, 'paste', reFormatCardNumber
     el
+  @getCardArray: ->
+    return cards;
+  @setCardArray: (cardArray) ->   
+    cards = cardArray;
+    return true
+  @addToCardArray: (cardObject) ->
+    cards.push(cardObject);    
+  @removeFromCardArray: (type) ->
+    for key, value of cards
+      if(value.type == type)
+        cards.splice(key, 1)
+    return true
 
 module.exports = Payment
 global.Payment = Payment


### PR DESCRIPTION
Added methods to expose the cards array.
- getCardArray : returns the card array
- setCardArray : overrides the existing card array with the given array
-  addToCardArray : adds the given card to the array.
- removeFromCardArray : removes the card with the given type key. 
**Note: This will remove all entries with that key however could be limited to the first one.**

We required the ability to override the card array using cardjs since we didn't support all the card types and while doing it decided all the options were easy enough to implement. This should also solve jessepollak/card#34 albeit in a rudimentary way.