### PR TITLE
Add 6703 prefix for Maestro cards

### DIFF
--- a/src/payment.coffee
+++ b/src/payment.coffee
@@ -53,7 +53,7 @@ cards = [
   }
   {
       type: 'maestro'
-      pattern: /^(5018|5020|5038|6304|6759|676[1-3])/
+      pattern: /^(5018|5020|5038|6304|6703|6759|676[1-3])/
       format: defaultFormat
       length: [12..19]
       cvcLength: [3]


### PR DESCRIPTION
Maestro cards can also begin with 6703. Therefore, failure to add this prefix results in not detecting all Maestro cards.

For example, ING in Belgium issues Maestro cards starting with 6703.