### PR TITLE
Updated visa card validation

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -320,7 +320,7 @@ cards = [
     type: 'visa',
     pattern: /^4/,
     format: defaultFormat,
-    length: [13, 14, 15, 16],
+    length: [13, 16],
     cvcLength: [3],
     luhn: true
   }

--- a/src/payment.coffee
+++ b/src/payment.coffee
@@ -87,7 +87,7 @@ cards = [
       type: 'visa'
       pattern: /^4/
       format: defaultFormat
-      length: [13..16]
+      length: [13, 16]
       cvcLength: [3]
       luhn: true
   }


### PR DESCRIPTION
VISA cards are either 13 or 16 digits long. Not 14 or 15.