### PR TITLE
move coffeeify to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "browserify": "~11.2.0",
     "coffee-script": "~1.10",
-    "coffeeify": "^1.1.0",
     "gulp": "~3.9.0",
     "gulp-autoprefixer": "3.0.2",
     "gulp-changed": "~1.3.0",
@@ -43,6 +42,7 @@
     "vinyl-source-stream": "~1.1.0"
   },
   "dependencies": {
-    "qj": "0.0.8"
+    "qj": "0.0.8",
+    "coffeeify": "^1.1.0"
   }
 }


### PR DESCRIPTION
move coffeeify to dependencies to fix - Cannot find module 'coffeeify' - error