### PR TITLE
Reject expiry month 0

### DIFF
--- a/lib/payment.js
+++ b/lib/payment.js
@@ -689,7 +689,8 @@ Payment = (function() {
       if (!/^\d+$/.test(year)) {
         return false;
       }
-      if (!(parseInt(month, 10) <= 12)) {
+      month = parseInt(month, 10);
+      if (!(month && month <= 12)) {
         return false;
       }
       if (year.length === 2) {

--- a/src/payment.coffee
+++ b/src/payment.coffee
@@ -396,7 +396,10 @@ class Payment
 
       return false unless /^\d+$/.test(month)
       return false unless /^\d+$/.test(year)
-      return false unless parseInt(month, 10) <= 12
+
+      month = parseInt(month, 10)
+
+      return false unless month and month <= 12
 
       if year.length is 2
         prefix = (new Date).getFullYear()

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -110,6 +110,11 @@ describe 'jquery.payment', ->
 
     it 'that has an invalid month', ->
       currentTime = new Date()
+      topic = Payment.fns.validateCardExpiry 0, currentTime.getFullYear()
+      assert.equal topic, false
+
+    it 'that has an invalid month', ->
+      currentTime = new Date()
       topic = Payment.fns.validateCardExpiry 13, currentTime.getFullYear()
       assert.equal topic, false
 


### PR DESCRIPTION
We have an issue where people can submit invalid expiration dates i.e 0/17

Currently it would be transformed to 12/16 and still be a valid expiration date.

* Check month for value other than 0.
* Adds a second invalid month test.