### PR TITLE
Add support for new MasterCard series 2 bins

### DIFF
--- a/src/payment.coffee
+++ b/src/payment.coffee
@@ -62,6 +62,7 @@ cards = [
   {
       type: 'mastercard'
       pattern: /^5[1-5]/
+      pattern: /^(5[1-5]|677189)|^(222[1-9]|2[3-6]\d{2}|27[0-1]\d|2720)/
       format: defaultFormat
       length: [16]
       cvcLength: [3]

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -63,6 +63,7 @@ describe 'payment', ->
       assert(Payment.fns.validateCardNumber('3566002020360505'), 'jcb')
     it 'should validate mastercard card types', ->
       assert(Payment.fns.validateCardNumber('5555555555554444'), 'mastercard')
+      assert(Payment.fns.validateCardNumber('2221000010000015'), 'mastercard')
     it 'should validate visa card types', ->
       assert(Payment.fns.validateCardNumber('4111111111111111'), 'visa')
       assert(Payment.fns.validateCardNumber('4012888888881881'), 'visa')
@@ -202,6 +203,10 @@ describe 'payment', ->
       topic = Payment.fns.cardType '5555555555554444'
       assert.equal topic, 'mastercard'
 
+    it 'that begins with 2 should return MasterCard', ->
+      topic = Payment.fns.cardType '2221000010000015'
+      assert.equal topic, 'mastercard'
+
     it 'that begins with 34 should return American Express', ->
       topic = Payment.fns.cardType '3412121212121212'
       assert.equal topic, 'amex'
@@ -233,13 +238,14 @@ describe 'payment', ->
       assert.equal(Payment.fns.cardType('3566002020360505'), 'jcb')
 
       assert.equal(Payment.fns.cardType('5555555555554444'), 'mastercard')
+      assert.equal(Payment.fns.cardType('2221000010000015'), 'mastercard')
 
       assert.equal(Payment.fns.cardType('4111111111111111'), 'visa')
       assert.equal(Payment.fns.cardType('4012888888881881'), 'visa')
       assert.equal(Payment.fns.cardType('4222222222222'), 'visa')
 
       assert.equal(Payment.fns.cardType('6759649826438453'), 'maestro')
-      
+
       assert.equal(Payment.fns.cardType('6363689826438453'), 'elo')
       assert.equal(Payment.fns.cardType('6362979826438453'), 'elo')
 
@@ -588,4 +594,3 @@ describe 'payment', ->
       cvc.dispatchEvent(ev)
 
       assert.equal QJ.val(cvc), '1234'
-


### PR DESCRIPTION
Fixes #33

* Updated regex for mastercard type to account for new series 2 range.
* Also added support for the '677189' versions of the card.

See: [this PR](https://github.com/thephpleague/omnipay-common/pull/88/) for further
details.