### PR TITLE
Allow «validateCardExpiry()» to recieve plain card expiry input value

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,14 @@ Example:
 Payment.fns.validateCardNumber('4242 4242 4242 4242'); //=> true
 ```
 
-### Payment.fns.validateCardExpiry(month, year)
+### Payment.fns.validateCardExpiry(month, year), Payment.fns.validateCardExpiry('month / year')
 
 Validates a card expiry:
 
 * Validates numbers
 * Validates in the future
 * Supports year shorthand
+* Supports formatted as `formatCardExpiry` input value
 
 Example:
 
@@ -115,6 +116,8 @@ Example:
 Payment.fns.validateCardExpiry('05', '20'); //=> true
 Payment.fns.validateCardExpiry('05', '2015'); //=> true
 Payment.fns.validateCardExpiry('05', '05'); //=> false
+Payment.fns.validateCardExpiry('05 / 25'); //=> true
+Payment.fns.validateCardExpiry('05 / 2015'); //=> false
 ```
 
 ### Payment.fns.validateCardCVC(cvc, type)

--- a/dist/payment.js
+++ b/dist/payment.js
@@ -495,9 +495,11 @@ var payment =
 	      return (ref = num.length, indexOf.call(card.length, ref) >= 0) && (card.luhn === false || luhnCheck(num));
 	    },
 	    validateCardExpiry: function(month, year) {
-	      var currentTime, expiry, prefix, ref;
+	      var currentTime, expiry, prefix, ref, ref1;
 	      if (typeof month === 'object' && 'month' in month) {
 	        ref = month, month = ref.month, year = ref.year;
+	      } else if (typeof month === 'string' && indexOf.call(month, '/') >= 0) {
+	        ref1 = Payment.fns.cardExpiryVal(month), month = ref1.month, year = ref1.year;
 	      }
 	      if (!(month && year)) {
 	        return false;

--- a/spec/index.spec.coffee
+++ b/spec/index.spec.coffee
@@ -141,6 +141,18 @@ describe 'payment', ->
       topic = Payment.fns.validateCardExpiry currentTime.getMonth() + '', currentTime.getFullYear() + ''
       assert.equal topic, true
 
+    it 'should validate a string with two digits month and year delimited by slash', ->
+      topic = Payment.fns.validateCardExpiry '03 / 25'
+      assert.equal topic, true
+
+    it 'should validate a string with two digits month and four digits year delimited by slash', ->
+      topic = Payment.fns.validateCardExpiry '03 / 2025'
+      assert.equal topic, true
+
+    it 'should fail if expires is string mm/yyyy where the year is before the current year', ->
+      topic = Payment.fns.validateCardExpiry '03 / 205'
+      assert.equal topic, false
+
     it 'that has non-numbers', ->
       topic = Payment.fns.validateCardExpiry 'h12', '3300'
       assert.equal topic, false

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -391,6 +391,8 @@ class Payment
       # Allow passing an object
       if typeof month is 'object' and 'month' of month
         {month, year} = month
+      else if typeof month is 'string' and '/' in month
+        {month, year} = Payment.fns.cardExpiryVal(month)
 
       return false unless month and year
 


### PR DESCRIPTION
I think, it would be better to allow `validateCardExpiry` method to recieve plain input value, just the same way like `validateCardNumber` and `validateCardCVC` behave. It's not breaking change and has backward-compatibility as well, but only adds one more signature to this method.

The purpose is because I'm trying to use **Payment** to make validation on my page and I want to make it via one general method, like this:

![image](https://cloud.githubusercontent.com/assets/2368213/17618880/5369cdda-60ac-11e6-99d5-b30f787f1f5f.png)

And, as you can see, `validateCardExpiry` doesn't work properly in this case, because it expects either `{month, year}` object, or separate `month` and `year` arguments.

Hope for your understanding:)