### PR TITLE
Fixing fns.formatCardNumber formatting of Amex numbers.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -448,7 +448,7 @@ class Payment
       if card.format.global
         num.match(card.format)?.join(' ')
       else
-        groups = card.format.exec(num)
+        groups = card.format.exec(num).filter(Number)
         groups?.shift()
         groups?.join(' ')
   @restrictNumeric: (el) ->


### PR DESCRIPTION
Payment.fns.formatCardNumber would format Amex (and Diner's Club) numbers a little oddly which led to bugs when dealing with formatted numbers like not being able to use the backspace key to delete numbers.

The bug seems to be caused by the way Javascript's exec/match functions return results. For cases with groups its returning undefined for groups that don't match. When the groups were joined this meant that extra spaces ended up in the output. This meant that in my implementation when users tried to use backspace to delete a space they couldn't because the space would always show up again once it was formatted. The default format doesn't have this problem because it doesn't use the regex group feature.

Examples:

input | regex.exec | output
------|---------|--------
"34" | ["34", "34", undefined, undefined] | "34  "
"344" | ["344", "344", undefined, undefined] | "344  "
"34444" | ["34444", "3444", "4", undefined] | "3444 4 "

The fix works by filtering out the undefineds by using the Number function as a test.