### PR TITLE
Fixed additional space being added at the end of a 16 digit Visa card

### DIFF
--- a/spec/index.spec.coffee
+++ b/spec/index.spec.coffee
@@ -397,7 +397,36 @@ describe 'payment', ->
       # done in a setTimeout
       setTimeout ->
         assert.equal QJ.val(number), '4242 4'
+    it 'should format cc number correctly when transitioning from one length limit to another', ->
+      number = document.createElement('input')
+      number.type = 'text'
+      QJ.val(number, '4111 1111 1111 1111')
 
+      Payment.formatCardNumber(number)
+
+      ev = document.createEvent "HTMLEvents"
+      ev.initEvent "keypress", true, true
+      ev.eventName = "keypress"
+      ev.which = "1".charCodeAt(0)
+
+      number.dispatchEvent(ev)
+
+      assert.equal QJ.val(number), '4111 1111 1111 1111 1'
+    it 'should format cc number correctly when a lesser length limit is reached', ->
+      number = document.createElement('input')
+      number.type = 'text'
+      QJ.val(number, '4111 1111 1111 111')
+
+      Payment.formatCardNumber(number)
+
+      ev = document.createEvent "HTMLEvents"
+      ev.initEvent "keypress", true, true
+      ev.eventName = "keypress"
+      ev.which = "1".charCodeAt(0)
+
+      number.dispatchEvent(ev)
+      
+      assert.equal QJ.val(number), '4111 1111 1111 1111'
 
   describe 'formatCardExpiry', ->
     it 'should add a slash after two numbers', ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -157,9 +157,16 @@ formatCardNumber = (e) ->
   card    = cardFromNumber(value + digit)
   length  = (value.replace(/\D/g, '') + digit).length
 
-  upperLength = 16
-  upperLength = card.length[card.length.length - 1] if card
-  return if length >= upperLength
+  upperLengths = [16]
+  upperLengths = card.length if card
+
+  # Return if an upper length has been reached
+  for upperLength, i in upperLengths
+    continue if length > upperLength and upperLengths[i+1]
+    return if length > upperLength
+    if length == upperLength
+      QJ.val(target, value + digit)
+      return
 
   # Return if focus isn't at the end of the text
   return if hasTextSelected(target)


### PR DESCRIPTION
I believe this fixes issue #56 where an additional space was being added to Visa cards when entered with only 16 digits.

An additional space in general should not be added when a card length has been reached. This code helps address this.

Would appreciate if this pull request could be given some urgency as we have a project dependent on this fix.