### PR TITLE
Add optional maxLength parameter to card number formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Supported card types are:
 
 ## API
 
-### Payment.formatCardNumber
+### Payment.formatCardNumber(element[, maxLength])
 Formats card numbers:
 
 * Includes a space between every 4 digits
@@ -44,6 +44,7 @@ Formats card numbers:
 * Limits to 16 numbers
 * Supports American Express formatting
 * Adds a class of the card type (e.g. 'visa') to the input
+* If second parameter is specified then card length will be limited to its value (19 digits cards are not in use despite being included in specifications)
 
 Example:
 
@@ -51,7 +52,7 @@ Example:
 Payment.formatCardNumber(document.querySelector('input.cc-num'));
 ```
 
-### Payment.formatCardExpiry
+### Payment.formatCardExpiry(element)
 
 Formats card expiry:
 
@@ -65,7 +66,7 @@ Example:
 Payment.formatCardExpiry(document.querySelector('input.cc-exp'));
 ```
 
-### Payment.formatCardCVC
+### Payment.formatCardCVC(element)
 Formats card CVC:
 
 * Restricts length to 4 numbers
@@ -77,7 +78,7 @@ Example:
 Payment.formatCardCVC(document.querySelector('input.cc-cvc'));
 ```
 
-### Payment.restrictNumeric
+### Payment.restrictNumeric(element)
 
 General numeric input restriction.
 

--- a/example/index.html
+++ b/example/index.html
@@ -53,7 +53,7 @@
       validation = document.querySelector('.validation');
 
     Payment.restrictNumeric(numeric);
-    Payment.formatCardNumber(number);
+    Payment.formatCardNumber(number, 16);
     Payment.formatCardExpiry(exp);
     Payment.formatCardCVC(cvc);
 

--- a/spec/index.spec.coffee
+++ b/spec/index.spec.coffee
@@ -297,6 +297,37 @@ describe 'payment', ->
       number.dispatchEvent(ev)
 
       assert.equal QJ.val(number), '4000 0000 0000 0000 030'
+
+    it 'should restrict characters for visa when a `maxLength` parameter is set despite card length can be 19', ->
+      number = document.createElement('input')
+      number.type = 'text'
+      QJ.val(number, '4242 4242 4242 4242')
+
+      Payment.formatCardNumber(number, 16)
+
+      ev = document.createEvent "HTMLEvents"
+      ev.initEvent "keypress", true, true
+      ev.eventName = "keypress"
+      ev.which = "0".charCodeAt(0)
+
+      number.dispatchEvent(ev)
+
+      assert.equal QJ.val(number), '4242 4242 4242 4242'
+    it 'should restrict characters correctly if `maxLength` exceeds max length for card', ->
+      number = document.createElement('input')
+      number.type = 'text'
+      QJ.val(number, '3472 486270 35790')
+
+      Payment.formatCardNumber(number, 16)
+
+      ev = document.createEvent "HTMLEvents"
+      ev.initEvent "keypress", true, true
+      ev.eventName = "keypress"
+      ev.which = "0".charCodeAt(0)
+
+      number.dispatchEvent(ev)
+
+      assert.equal QJ.val(number), '3472 486270 35790'
     it 'should format cc number correctly', ->
       number = document.createElement('input')
       number.type = 'text'


### PR DESCRIPTION
Since card numbers longer than 16 digits are not in use as for now it is sometimes better to limit possible input value to some other length (longer numbers are still valid as per the specification).