### PR TITLE
* Add BCMC cards support.

### DIFF
--- a/spec/index.spec.coffee
+++ b/spec/index.spec.coffee
@@ -84,6 +84,8 @@ describe 'payment', ->
       assert(Payment.fns.validateCardNumber('6012135281693108'), 'hipercard')
       assert(Payment.fns.validateCardNumber('38410036464094'), 'hipercard')
       assert(Payment.fns.validateCardNumber('38414050328938'), 'hipercard')
+    it 'should validate bcmc card types', ->
+      assert(Payment.fns.validateCardNumber('67030000000000003'), 'bcmc')
 
   describe 'Validating a CVC', ->
     it 'should fail if is empty', ->
@@ -226,6 +228,10 @@ describe 'payment', ->
     it 'that begins with 34 should return American Express', ->
       topic = Payment.fns.cardType '3412121212121212'
       assert.equal topic, 'amex'
+
+    it 'that begins with 6703 should return Bcmc', ->
+      topic = Payment.fns.cardType '67030000000000003'
+      assert.equal topic, 'bcmc'
 
     it 'that begins with 457393 should return Elo', ->
       topic = Payment.fns.cardType '4573931212121212'

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,6 +11,14 @@ cards = [
       cvcLength: [4]
       luhn: true
   }
+ {
+    type: 'bcmc',
+    pattern: /^6703/,
+    format: defaultFormat,
+    length: [12..19],
+    cvcLength: [0],
+    luhn: true
+  }
   {
       type: 'dankort',
       pattern: /^5019/,
@@ -61,7 +69,7 @@ cards = [
   }
   {
       type: 'maestro'
-      pattern: /^(5018|5020|5038|6304|6703|6708|6759|676[1-3])/
+      pattern: /^(5018|5020|5038|6304|6708|6759|676[1-3])/
       format: defaultFormat
       length: [12..19]
       cvcLength: [3]


### PR DESCRIPTION
Add support for BCMC Maestro cards. BCMC is a very popular payment method in Belgium. These are maestro cards but without CVC.