### PR TITLE
Updated JCB card schema with new length

### DIFF
--- a/spec/index.spec.coffee
+++ b/spec/index.spec.coffee
@@ -57,6 +57,7 @@ describe 'payment', ->
     it 'should validate jcb card types', ->
       assert(Payment.fns.validateCardNumber('3530111333300000'), 'jcb')
       assert(Payment.fns.validateCardNumber('3566002020360505'), 'jcb')
+      assert(Payment.fns.validateCardNumber('3536408073177691495'), 'jcb')
     it 'should validate mastercard card types', ->
       assert(Payment.fns.validateCardNumber('5555555555554444'), 'mastercard')
       assert(Payment.fns.validateCardNumber('2221000010000015'), 'mastercard')

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -47,7 +47,7 @@ cards = [
       type: 'jcb'
       pattern: /^35/
       format: defaultFormat
-      length: [16]
+      length: [16..19]
       cvcLength: [3]
       luhn: true
   }


### PR DESCRIPTION
[As of February 2017, JCB cards can be 16-19 digits long](https://www.discovernetwork.com/downloads/IPP_VAR_Compliance.pdf). This updates the validation to use the new lengths.

Also [see here](https://www.freeformatter.com/credit-card-number-generator-validator.html) example 19-digit numbers.